### PR TITLE
Add Load more pagination to exercise history

### DIFF
--- a/src/lib/components/training-log/PastPerformancesList.svelte
+++ b/src/lib/components/training-log/PastPerformancesList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { formatDate } from '$lib/ui/formatDate';
 	import { ScrollArea } from '$lib/shadcn/scroll-area';
+	import Button from '$lib/shadcn/button/button.svelte';
 	import EmptyState from '$lib/components/ui/EmptyState.svelte';
 	import PastPerformanceSets from '$lib/components/training-log/PastPerformanceSets.svelte';
 	import { Exercise } from '$lib/jazz/schema';
@@ -20,9 +21,16 @@
 		}
 	});
 
+	const PAGE_SIZE = 10;
 	const exercise = $derived(exerciseState.current.$isLoaded ? exerciseState.current : null);
+	let visibleCount = $state(PAGE_SIZE);
 
-	const performanceItems = $derived.by(() => {
+	$effect(() => {
+		exerciseId;
+		visibleCount = PAGE_SIZE;
+	});
+
+	const sortedPerformanceItems = $derived.by(() => {
 		if (!exercise?.performances) {
 			return [];
 		}
@@ -38,27 +46,40 @@
 				}
 				return workoutDate.getTime() < todayDate.getTime();
 			})
-			.toSorted((a, b) => (b.workoutDate?.getTime() ?? 0) - (a.workoutDate?.getTime() ?? 0))
-			.slice(0, 10);
+			.toSorted((a, b) => (b.workoutDate?.getTime() ?? 0) - (a.workoutDate?.getTime() ?? 0));
 	});
+
+	const performanceItems = $derived(sortedPerformanceItems.slice(0, visibleCount));
+	const hasMore = $derived(sortedPerformanceItems.length > performanceItems.length);
+
+	const loadMore = () => {
+		visibleCount += PAGE_SIZE;
+	};
 </script>
 
 {#if performanceItems.length}
-	<ScrollArea class="h-[50vh]">
-		<ul class="divide-border flex flex-col gap-4 divide-y pt-4 pb-7">
-			{#each performanceItems as performance (performance.$jazz.id)}
-				<li class="flex flex-col gap-3 pb-4">
-					<div class="flex flex-col gap-1">
-						<h4 class="text-base font-semibold">{formatDate(performance.workoutDate)}</h4>
-						{#if performance.note}
-							<p class="text-muted-foreground text-sm">{performance.note}</p>
-						{/if}
-					</div>
-					<PastPerformanceSets performanceId={performance.$jazz.id} />
-				</li>
-			{/each}
-		</ul>
-	</ScrollArea>
+	<div class="space-y-3">
+		<ScrollArea class="h-[50vh]">
+			<ul class="divide-border flex flex-col gap-4 divide-y pt-4 pb-2">
+				{#each performanceItems as performance (performance.$jazz.id)}
+					<li class="flex flex-col gap-3 pb-4">
+						<div class="flex flex-col gap-1">
+							<h4 class="text-base font-semibold">{formatDate(performance.workoutDate)}</h4>
+							{#if performance.note}
+								<p class="text-muted-foreground text-sm">{performance.note}</p>
+							{/if}
+						</div>
+						<PastPerformanceSets performanceId={performance.$jazz.id} />
+					</li>
+				{/each}
+			</ul>
+		</ScrollArea>
+		{#if hasMore}
+			<div class="flex justify-center pb-2">
+				<Button variant="secondary" size="sm" onclick={loadMore}>Load more</Button>
+			</div>
+		{/if}
+	</div>
 {:else if exercise?.$isLoaded}
 	<div class="my-7">
 		<EmptyState title="No history yet">


### PR DESCRIPTION
## Summary
- Keep fast initial history load to 10 items
- Add local pagination state (visibleCount) with page size 10
- Add a Load more button to reveal additional batches of 10
- Reset visible count when exerciseId changes

## Why
This keeps initial history render fast for large exercises while still allowing users to access older performances on demand.

## Notes
This intentionally uses a button (not infinite scroll) for predictable behavior and lower complexity.