### PR TITLE
Fix workout-delete history cleanup + migrate noisy zero-rep history

### DIFF
--- a/src/lib/jazz/schema.ts
+++ b/src/lib/jazz/schema.ts
@@ -198,7 +198,7 @@ export const AccountRoot = co
 		onInlineCreate: 'extendsContainer'
 	});
 
-const CURRENT_MIGRATION_VERSION = 1;
+const CURRENT_MIGRATION_VERSION = 2;
 
 export const IronkitAccount = co
 	.account({
@@ -235,21 +235,25 @@ export const IronkitAccount = co
 			return;
 		}
 
-		// Skip expensive migration if already at current version
 		const { root: rootForVersionCheck } = await account.$jazz.ensureLoaded({
 			resolve: { root: true }
 		});
-		if (rootForVersionCheck.migrationVersion === CURRENT_MIGRATION_VERSION) {
+		const existingMigrationVersion = rootForVersionCheck.migrationVersion ?? 0;
+		if (existingMigrationVersion >= CURRENT_MIGRATION_VERSION) {
 			return;
 		}
 
-		// Migration v1: Backfill exercise.performances reverse-lookup lists
 		const { root } = await account.$jazz.ensureLoaded({
 			resolve: {
 				root: {
 					exercises: {
 						$each: {
-							performances: { $each: true }
+							performances: {
+								$each: {
+									$onError: 'catch',
+									performanceSets: { $each: { $onError: 'catch' } }
+								}
+							}
 						}
 					},
 					workouts: {
@@ -271,33 +275,64 @@ export const IronkitAccount = co
 			}
 		});
 
-		// Initialize empty performances list on existing exercises
-		root.exercises.forEach((exercise) => {
-			if (!exercise.performances) {
-				exercise.$jazz.set('performances', []);
-			}
-		});
+		if (existingMigrationVersion < 1) {
+			// Migration v1: Backfill exercise.performances reverse-lookup lists
+			root.exercises.forEach((exercise) => {
+				if (!exercise.performances) {
+					exercise.$jazz.set('performances', []);
+				}
+			});
 
-		// Backfill workoutDate/workoutId and populate exercise.performances
-		root.workouts.forEach((workout) => {
-			workout.performanceGroups.forEach((group) => {
-				group.performances.forEach((performance) => {
-					if (!performance.workoutDate) {
-						performance.$jazz.set('workoutDate', workout.date);
-					}
-					if (!performance.workoutId) {
-						performance.$jazz.set('workoutId', workout.$jazz.id);
-					}
-					const exercisePerformances = performance.exercise.performances;
-					const alreadyInList = exercisePerformances.some(
-						(p) => p.$jazz.id === performance.$jazz.id
-					);
-					if (!alreadyInList) {
-						exercisePerformances.$jazz.push(performance);
-					}
+			root.workouts.forEach((workout) => {
+				workout.performanceGroups.forEach((performanceGroup) => {
+					performanceGroup.performances.forEach((performance) => {
+						if (!performance.workoutDate) {
+							performance.$jazz.set('workoutDate', workout.date);
+						}
+						if (!performance.workoutId) {
+							performance.$jazz.set('workoutId', workout.$jazz.id);
+						}
+						const exercisePerformances = performance.exercise.performances;
+						const isAlreadyInExerciseHistory = exercisePerformances.some(
+							(exercisePerformance) => exercisePerformance.$jazz.id === performance.$jazz.id
+						);
+						if (!isAlreadyInExerciseHistory) {
+							exercisePerformances.$jazz.push(performance);
+						}
+					});
 				});
 			});
-		});
+		}
+
+		if (existingMigrationVersion < 2) {
+			// Migration v2: Remove test performances from exercise history when all set reps are missing/zero
+			root.exercises.forEach((exercise) => {
+				if (!exercise.performances.$isLoaded) {
+					return;
+				}
+
+				exercise.performances.$jazz.remove((exercisePerformance) => {
+					if (!exercisePerformance.$isLoaded) {
+						return false;
+					}
+					if (!exercisePerformance.performanceSets.$isLoaded) {
+						return false;
+					}
+
+					const loadedPerformanceSets = exercisePerformance.performanceSets.filter(
+						(performanceSet) => performanceSet.$isLoaded
+					);
+					if (loadedPerformanceSets.length === 0) {
+						return false;
+					}
+
+					return loadedPerformanceSets.every((performanceSet) => {
+						const reps = performanceSet.reps;
+						return reps == null || reps === 0;
+					});
+				});
+			});
+		}
 
 		root.$jazz.set('migrationVersion', CURRENT_MIGRATION_VERSION);
 	});

--- a/src/routes/(app)/tools/training-log/+page.svelte
+++ b/src/routes/(app)/tools/training-log/+page.svelte
@@ -106,22 +106,26 @@
 				}
 			}
 		});
-		const performances = loadedWorkout.performanceGroups.flatMap((g) => g.performances);
+		const performances = loadedWorkout.performanceGroups.flatMap((performanceGroup) =>
+			performanceGroup.performances
+		);
 
-		performances.forEach((p) => {
-			if (!p.$isLoaded) {
+		performances.forEach((performance) => {
+			if (!performance.$isLoaded) {
 				return;
 			}
-			if (!p.exercise.$isLoaded) {
+			if (!performance.exercise.$isLoaded) {
 				return;
 			}
-			if (!p.exercise.performances.$isLoaded) {
+			if (!performance.exercise.performances.$isLoaded) {
 				return;
 			}
-			p.exercise.performances.$jazz.remove((e) => e.$jazz.id === p.exercise.$jazz.id);
+			performance.exercise.performances.$jazz.remove(
+				(exercisePerformance) => exercisePerformance.$jazz.id === performance.$jazz.id
+			);
 		});
 
-		root.workouts.$jazz.remove((w) => w.$jazz.id === workoutId);
+		root.workouts.$jazz.remove((workoutItem) => workoutItem.$jazz.id === workoutId);
 		deleteCoValues(Workout, workoutId, {
 			resolve: {
 				performanceGroups: {


### PR DESCRIPTION
## Summary
- Fix `deleteWorkout` reverse-lookup cleanup to remove the deleted performance from `exercise.performances`
- Replace single-letter predicate variables in touched logic with descriptive names
- Add migration v2 that removes exercise-history performances where all loaded sets have `reps` as `0` or `null/undefined`

## Details
### 1) Workout delete cleanup bug fix
In `deleteWorkout`, the removal predicate compared against the exercise id instead of the performance id.

Now it correctly removes by performance id:
- before: `exercisePerformance.id === exercise.id` (incorrect)
- after: `exercisePerformance.id === performance.id` (correct)

### 2) Readability improvements
In the touched predicates/loops, single-letter names were replaced with explicit names such as:
- `performanceGroup`, `performance`, `exercisePerformance`, `workoutItem`

### 3) Migration v2 cleanup
Bumped `CURRENT_MIGRATION_VERSION` to `2` and added a new migration step that:
- iterates each exercise's history (`exercise.performances`)
- removes history performances only when:
  - performance + its set list are loaded
  - at least one set is loaded
  - every loaded set has `reps` missing (`null/undefined`) or `0`

This targets leftover test data polluting history, without deleting performances that have meaningful reps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data integrity for exercise performance records by removing incomplete test performances from exercise history.
  * Enhanced workout deletion to properly clean up associated performance data and maintain consistent references.

* **Refactor**
  * Optimized internal data migration processes for better handling of exercise and performance relationships.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->