### PR TITLE
Harden migration v2 to prevent blank-screen startup failures

### DIFF
--- a/src/lib/jazz/schema.ts
+++ b/src/lib/jazz/schema.ts
@@ -243,27 +243,24 @@ export const IronkitAccount = co
 			return;
 		}
 
-		const { root } = await account.$jazz.ensureLoaded({
-			resolve: {
-				root: {
-					exercises: {
-						$each: {
-							performances: {
-								$each: {
-									$onError: 'catch',
-									performanceSets: { $each: { $onError: 'catch' } }
-								}
+		if (existingMigrationVersion < 1) {
+			const { root } = await account.$jazz.ensureLoaded({
+				resolve: {
+					root: {
+						exercises: {
+							$each: {
+								performances: { $each: true }
 							}
-						}
-					},
-					workouts: {
-						$each: {
-							performanceGroups: {
-								$each: {
-									performances: {
-										$each: {
-											exercise: {
-												performances: { $each: true }
+						},
+						workouts: {
+							$each: {
+								performanceGroups: {
+									$each: {
+										performances: {
+											$each: {
+												exercise: {
+													performances: { $each: true }
+												}
 											}
 										}
 									}
@@ -272,10 +269,8 @@ export const IronkitAccount = co
 						}
 					}
 				}
-			}
-		});
+			});
 
-		if (existingMigrationVersion < 1) {
 			// Migration v1: Backfill exercise.performances reverse-lookup lists
 			root.exercises.forEach((exercise) => {
 				if (!exercise.performances) {
@@ -305,8 +300,32 @@ export const IronkitAccount = co
 		}
 
 		if (existingMigrationVersion < 2) {
+			const { root } = await account.$jazz.ensureLoaded({
+				resolve: {
+					root: {
+						exercises: {
+							$each: {
+								$onError: 'catch',
+								performances: {
+									$each: {
+										$onError: 'catch',
+										performanceSets: { $each: { $onError: 'catch' } }
+									}
+								}
+							}
+						}
+					}
+				}
+			});
+
 			// Migration v2: Remove test performances from exercise history when all set reps are missing/zero
 			root.exercises.forEach((exercise) => {
+				if (!exercise.$isLoaded) {
+					return;
+				}
+				if (!exercise.performances) {
+					return;
+				}
 				if (!exercise.performances.$isLoaded) {
 					return;
 				}
@@ -334,5 +353,5 @@ export const IronkitAccount = co
 			});
 		}
 
-		root.$jazz.set('migrationVersion', CURRENT_MIGRATION_VERSION);
+		rootForVersionCheck.$jazz.set('migrationVersion', CURRENT_MIGRATION_VERSION);
 	});


### PR DESCRIPTION
## Summary
- Split migration data loading by version step instead of one giant resolve
- Add additional loaded/exists guards in v2 cleanup path
- Set  on the already-loaded root version-check object

## Why
After merging the previous cleanup PR, migration v2 could over-resolve and hit fragile startup paths for some datasets, resulting in a blank screen.

## Result
Migration remains functionally the same, but is now much safer and less likely to crash startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data migration reliability with enhanced error handling and defensive checks to ensure safer data transitions during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->